### PR TITLE
Adjust question indicators for question set

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -46,7 +46,7 @@ QUESTIONS: List[Question] = [
     Question(
         "inf_rules_only",
         "Does it work following only human-programmed rules?",
-        {"yes": "not_ai_ind", "no": "def_not_ai"},
+        {"yes": "def_not_ai", "no": "ai_ind"},
         "rules_only",
     ),
     Question(
@@ -98,7 +98,7 @@ QUESTIONS: List[Question] = [
     Question(
         "auton_full_autonomy",
         "Does it act with full autonomy, making decisions that directly affect the world without human review?",
-        {"yes": "ai_ind", "no": "def_not_ai"},
+        {"yes": "ai_ind", "no": "not_ai_ind"},
         "acts_full_autonomy",
     ),
     Question(


### PR DESCRIPTION
## Summary
- Update `inf_rules_only` question to mark "yes" as definitive non-AI and "no" as an AI indicator
- Treat a "no" response to `auton_full_autonomy` as a not-AI indicator instead of a definitive non-AI

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3d4c8ef1883218c76d61966413a6c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated answer-to-indicator mapping for two questionnaire items, adjusting how Yes/No responses influence scoring and the final guess.
  - Users may notice changes in per-question feedback and overall results for those items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->