### PR TITLE
Remove technical properties expander

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -609,9 +609,6 @@ with st.container(border=True):
         st.markdown("**Output**")
         st.write(secs.get("Output", ""))
 
-with st.expander("Optional: technical properties (for advanced players)"):
-    st.code(current_card.props, language="python")
-
 st.caption(
     "You know the card and what it does—but not whether it's an AI system. The Computer will try to guess using yes/no questions."
 )


### PR DESCRIPTION
## Summary
- remove optional technical properties code block for advanced players

## Testing
- `pytest`
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3d78c5908832186644329fe48e4fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the card view by removing the “Optional: technical properties (for advanced players)” expander.
  * Technical details are no longer displayed, resulting in a cleaner, less distracting interface.
  * Core card content and captions remain unchanged, preserving the primary experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->