### PR TITLE
feat: add two-mode AI Guess Who

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # 🃏 AI Guess Who
 
-A simple Streamlit game where the computer tries to guess whether a card describes an AI system.
-You, the player, select a card describing a technology. The computer then asks up to five yes/no
-questions and makes a final determination of “AI” or “Not AI”.
+A simple Streamlit game with two modes:
+
+* **Computer guesses (app asks):** You select a card describing a technology and answer up to five yes/no
+  questions from the computer, which then tries to guess whether the system is “AI” or “Not AI”.
+* **You guess (you ask):** The computer secretly chooses a card. You may ask up to five questions from the
+  list before making your own guess of “AI” or “Not AI”.
 
 ## Running locally
 


### PR DESCRIPTION
## Summary
- refactor Streamlit app to support both computer and player guessing modes
- document dual game modes and existing setup in README

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3fbe9d2f48321bf6a406395b30cbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two game modes: Computer guesses (it asks you) and You guess (you ask).
  - Sidebar setup to choose mode and card selection; “Start new game” and “Play again” flows.
  - Tracks progress, Q&A history, per-question indicators, and provides a final reveal with optional post-game indicators.
  - Optional technical properties panel for advanced players.

- UI/UX
  - Mode A shows full card details; Mode B hides AI status until reveal.
  - Updated footer and clearer in-app texts.

- Documentation
  - README updated to describe both modes with concise, bulletized guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->