### PR TITLE
Fix question selection parsing in you-guess mode

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -802,7 +802,7 @@ else:
         picked = st.selectbox(
             "Choose a question to ask:", options=q_labels, key="you_pick_q"
         )
-        selected_id = picked.split("|")[-1]
+        selected_id = picked.split("|")[-1].strip()
         selected_q = next(q for q in QUESTIONS if q.id == selected_id)
 
         if st.button("Ask this question", type="primary"):


### PR DESCRIPTION
## Summary
- Trim extra whitespace from question ID selection in you-guess mode
- Prevent `StopIteration` when the user asks a question

## Testing
- `python -m py_compile streamlit_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3fcebf6dc8321bce6d34c201c038b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in “You guess” mode where selecting options with labels like “text | id” could fail to load the correct question due to stray spaces in the ID. The app now accurately recognizes the selected question, preventing mismatches and errors.
  * Improved reliability and consistency of question lookup after selection, ensuring smoother progression through questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->