### PR TITLE
Remove technical properties expander

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -619,9 +619,6 @@ if game["mode"] == "computer_guesses":
             st.markdown("**Output**")
             st.write(secs.get("Output", ""))
 
-    with st.expander("Optional: technical properties (for advanced players)"):
-        st.code(current_card.props, language="python")
-
     st.caption(
         "You know the card details—but not whether it’s an AI system. The Computer will try to guess using yes/no questions."
     )


### PR DESCRIPTION
## Summary
- remove optional technical properties expander from the card display, simplifying the interface for players

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4000969c483218c2c96d7f7897336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the optional technical properties panel previously available to advanced users in Computer guesses mode. The interface no longer displays detailed card property readouts.
  * Gameplay, scoring, and guessing behavior remain unchanged.
  * No other screens are affected, and there are no changes to settings or performance.
  * This change only adjusts what is shown during play when the computer is guessing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->