### PR TITLE
Fix reveal card HTML rendering

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1070,15 +1070,17 @@ if game["completed"] and game["user_final_guess"] is not None:
         else:
             formatted = "<span class='reveal-card__empty'>No details provided.</span>"
         section_html_parts.append(
-            f"""
-            <div class=\"reveal-card__section\">
-                <div class=\"reveal-card__section-label\">{emoji} {section_name}</div>
-                <div class=\"reveal-card__section-body\">{formatted}</div>
-            </div>
-            """
+            textwrap.dedent(
+                f"""
+                <div class=\"reveal-card__section\">
+                    <div class=\"reveal-card__section-label\">{emoji} {section_name}</div>
+                    <div class=\"reveal-card__section-body\">{formatted}</div>
+                </div>
+                """
+            ).strip()
         )
     sections_html = "\n".join(section_html_parts)
-    st.markdown(
+    reveal_html = textwrap.dedent(
         f"""
         <div class=\"reveal-card\">
             <div class=\"reveal-card__header\">
@@ -1092,7 +1094,10 @@ if game["completed"] and game["user_final_guess"] is not None:
                 {sections_html}
             </div>
         </div>
-        """,
+        """
+    ).strip()
+    st.markdown(
+        reveal_html,
         unsafe_allow_html=True,
     )
 


### PR DESCRIPTION
## Summary
- strip leading indentation from reveal section HTML blocks so Streamlit renders the markup instead of showing it as plain text
- build the reveal card markup with `textwrap.dedent` before passing it to `st.markdown`

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cd16a049708321b0d03cdc966f399b