### PR TITLE
Normalize description text flow

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -202,7 +202,11 @@ QUESTIONS: List[Question] = [
 
 
 def wrap_desc(s: str) -> str:
-    return "\n".join(textwrap.wrap(s, width=100))
+    """Normalize description/summary text without forcing manual line breaks."""
+
+    normalized = textwrap.dedent(s).strip()
+    # Collapse any internal whitespace so HTML can flow the text naturally based on layout.
+    return re.sub(r"\s+", " ", normalized)
 
 
 BASE_DEFAULTS = {


### PR DESCRIPTION
## Summary
- update card copy normalization to remove forced hard line breaks so the interface can wrap copy responsively

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cd18f5436083218be17c5ae233525b