### PR TITLE
Disable Streamlit telemetry

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,11 +1,16 @@
 import html
+import os
 import random
 import re
 import textwrap
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
+os.environ["STREAMLIT_TELEMETRY"] = "0"
+
 import streamlit as st
+
+st.set_option("browser.gatherUsageStats", False)
 
 # =========================
 # Types & constants


### PR DESCRIPTION
## Summary
- disable Streamlit telemetry collection by setting the STREAMLIT_TELEMETRY environment flag
- turn off browser usage statistics collection at app startup

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3aae5c048321bf5663a48c797245