### PR TITLE
Fix Streamlit telemetry disabling

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,9 +1,13 @@
 import html
+import os
 import random
 import re
 import textwrap
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
+
+os.environ.setdefault("STREAMLIT_TELEMETRY", "0")
+os.environ.setdefault("STREAMLIT_BROWSER_GATHERUSAGESTATS", "false")
 
 import streamlit as st
 


### PR DESCRIPTION
## Summary
- set default environment variables to disable Streamlit telemetry collection safely

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3aae5c048321bf5663a48c797245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Defaulted telemetry and browser usage statistics to off, enhancing user privacy out of the box.
  * Honors any existing user or deployment configurations; settings are only applied when not already defined.
  * No impact on app functionality or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->