### PR TITLE
Add privacy info toggle to explain anonymous usage

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -707,6 +707,37 @@ def reset_game(pick_card_id: Optional[str] = None):
 st.set_page_config(page_title="AI Guess Who?", page_icon="🕵️", layout="centered")
 st.title("🕵️  AI Guess Who?")
 
+if "show_privacy_info" not in st.session_state:
+    st.session_state.show_privacy_info = False
+
+privacy_button_label = (
+    "🔐 Show privacy & anonymity info"
+    if not st.session_state.show_privacy_info
+    else "Hide privacy & anonymity info"
+)
+
+if st.button(
+    privacy_button_label,
+    key="toggle_privacy_info",
+    type="secondary",
+    use_container_width=True,
+):
+    st.session_state.show_privacy_info = not st.session_state.show_privacy_info
+
+if st.session_state.show_privacy_info:
+    st.info(
+        """
+        **No personal data is collected, your provided answers and interactions are not stored, and using this app is fully anonymous.**
+
+        **Overview of our privacy analysis:**
+        - Gameplay progress lives only inside your local Streamlit session (the drawn card, the preset questions you picked, whether you finished the round, and your final guess).
+        - Interactions rely solely on built-in widgets (radio buttons, select boxes, and buttons), so you never submit custom text or files to the app.
+        - The AI-generated-content disclaimer runs entirely in your browser and simply updates local session state when you dismiss it.
+        - Streamlit telemetry is disabled (`gatherUsageStats = false`), preventing usage statistics from being sent to Streamlit Cloud.
+        """,
+        icon="🔐",
+    )
+
 # --- Sidebar: new game ---
 with st.sidebar:
     st.header("New game")


### PR DESCRIPTION
## Summary
- add a toggle button near the title so users can open dedicated privacy information
- show an info panel summarizing that no personal data or interactions are stored and usage is anonymous

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cea5edc7948321b0bd0518efd2a449