### PR TITLE
Update privacy and AI info text

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -736,10 +736,9 @@ if st.session_state.show_privacy_info:
         """
         **No personal data is collected, your provided answers and interactions are not stored, and using this app is fully anonymous.**
 
-        **Overview of our privacy analysis:**
-        - Gameplay progress lives only inside your local Streamlit session (the drawn card, the preset questions you picked, whether you finished the round, and your final guess).
+        - Gameplay progress lives only inside your local session (the drawn card, the preset questions you picked, whether you finished the round, and your final guess).
         - Interactions rely solely on built-in widgets (radio buttons, select boxes, and buttons), so you never submit custom text or files to the app.
-        - Streamlit telemetry is disabled (`gatherUsageStats = false`), preventing usage statistics from being sent to Streamlit Cloud.
+        - Telemetry is disabled, preventing usage statistics from being collected.
         """,
         icon="🔐",
     )
@@ -762,7 +761,7 @@ st.button(
 if st.session_state.show_ai_info:
     st.info(
         """
-        Please note that some of the code and content of this app has been AI generated. Humans have reviewed all AI generated content. Always remember to label AI-generated content when sharing it.
+        Some of the code and content of this app has been AI generated. Humans have reviewed all AI generated content. Remember to label AI-generated content when sharing it.
         """,
         icon="ℹ️",
     )


### PR DESCRIPTION
## Summary
- update the privacy callout text to reflect the latest local-session and telemetry details while restoring the personal data reminder paragraph
- refresh the AI information message with the new wording about reviewed content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceb3fab8d883218ce8735732cf0511