### PR TITLE
Clarify privacy info messaging

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -734,6 +734,8 @@ st.button(
 if st.session_state.show_privacy_info:
     st.info(
         """
+        No personal data is collected—each game session is fully anonymous and none of your answers are saved or stored.
+
         - Gameplay progress lives only inside your local session (the drawn card, the preset questions you picked, whether you finished the round, and your final guess).
         - Interactions rely solely on built-in widgets (radio buttons, select boxes, and buttons), so you never submit custom text or files to the app.
         - Telemetry is disabled, preventing usage statistics from being collected.


### PR DESCRIPTION
## Summary
- add an explicit note that sessions are anonymous and answers are not stored in the privacy info box

## Testing
- not run (text-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ceb645dbe08321870ff0df3f5602d7