### PR TITLE
Adjust info toggle buttons for mobile

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -729,7 +729,7 @@ if "show_ai_info" not in st.session_state:
     st.session_state.show_ai_info = False
 
 
-toggle_privacy_col, toggle_ai_col, _info_toggle_spacer = st.columns([1, 1, 6])
+toggle_privacy_col, toggle_ai_col = st.columns(2, gap="small")
 with toggle_privacy_col:
     st.markdown('<div class="info-toggle">', unsafe_allow_html=True)
     if st.button(
@@ -826,31 +826,51 @@ st.markdown(
         display: flex;
         justify-content: flex-start;
         align-items: center;
-        padding-top: 0.15rem;
+        padding-top: 0;
+        margin: 0.1rem 0 0.2rem;
         width: fit-content;
     }
     .info-toggle button {
-        border-radius: 0.45rem;
-        padding: 0.3rem 0.65rem;
-        font-size: 0.75rem;
+        border-radius: 0.4rem;
+        padding: 0.22rem 0.6rem;
+        font-size: 0.72rem;
         font-weight: 600;
-        background: rgba(148, 163, 184, 0.14);
-        border: 1px solid rgba(148, 163, 184, 0.6);
+        background: rgba(148, 163, 184, 0.12);
+        border: 1px solid rgba(148, 163, 184, 0.55);
         color: #0f172a;
         white-space: nowrap;
         transition: background 0.15s ease, border-color 0.15s ease,
             color 0.15s ease, box-shadow 0.15s ease;
-        box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+        box-shadow: 0 1px 4px rgba(15, 23, 42, 0.08);
+        line-height: 1.1;
     }
     .info-toggle button:hover {
-        background: rgba(59, 130, 246, 0.2);
-        border-color: rgba(59, 130, 246, 0.5);
+        background: rgba(59, 130, 246, 0.18);
+        border-color: rgba(59, 130, 246, 0.48);
         color: #1d4ed8;
-        box-shadow: 0 4px 12px rgba(59, 130, 246, 0.18);
+        box-shadow: 0 3px 10px rgba(59, 130, 246, 0.16);
     }
     .info-toggle button:focus {
-        outline: 2px solid rgba(59, 130, 246, 0.5);
+        outline: 2px solid rgba(59, 130, 246, 0.45);
         outline-offset: 1px;
+    }
+    [data-testid="stHorizontalBlock"]:has(.info-toggle) {
+        gap: 0.45rem;
+        flex-wrap: nowrap;
+        align-items: center;
+        margin-bottom: 0.35rem;
+    }
+    [data-testid="stHorizontalBlock"]:has(.info-toggle) > div[data-testid="column"] {
+        flex: 0 0 auto;
+    }
+    @media (max-width: 640px) {
+        .info-toggle button {
+            font-size: 0.68rem;
+            padding: 0.2rem 0.55rem;
+        }
+        [data-testid="stHorizontalBlock"]:has(.info-toggle) {
+            gap: 0.35rem;
+        }
     }
     .subtle-callout {
         background: rgba(241, 245, 249, 0.65);


### PR DESCRIPTION
## Summary
- keep the privacy and AI info toggles in a compact two-column layout so they stay together on small screens
- shrink and restyle the toggle buttons with lighter padding, rounded corners, and subtler shadows for better mobile presentation
- add responsive CSS rules to prevent wrapping and tighten spacing around the toggles

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68ced5adfc908321b53520cf64d08504