### PR TITLE
Adjust sidebar info toggles

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -746,49 +746,48 @@ with st.sidebar:
         reset_game(chosen_id)
         st.rerun()
 
-    with st.expander("Show/hide info", expanded=False):
-        st.caption("Toggle the notices below to learn about privacy and AI content in this app.")
+    st.caption("Toggle the notices below to learn about privacy and AI content in this app.")
 
-        st.markdown('<div class="info-toggle">', unsafe_allow_html=True)
-        if st.button(
-            "🔐 Privacy info",
-            key="privacy_info_button",
-            help="Show or hide privacy details.",
-        ):
-            st.session_state.show_privacy_info = not st.session_state.show_privacy_info
-        st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown('<div class="info-toggle">', unsafe_allow_html=True)
+    if st.button(
+        "🔐 Privacy info",
+        key="privacy_info_button",
+        help="Show or hide privacy details.",
+    ):
+        st.session_state.show_privacy_info = not st.session_state.show_privacy_info
+    st.markdown("</div>", unsafe_allow_html=True)
 
-        st.markdown('<div class="info-toggle">', unsafe_allow_html=True)
-        if st.button(
-            "🤖 AI content notice",
-            key="ai_info_button",
-            help="Show or hide AI-generated content notes.",
-        ):
-            st.session_state.show_ai_info = not st.session_state.show_ai_info
-        st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown('<div class="info-toggle">', unsafe_allow_html=True)
+    if st.button(
+        "🤖 AI content notice",
+        key="ai_info_button",
+        help="Show or hide AI-generated content notes.",
+    ):
+        st.session_state.show_ai_info = not st.session_state.show_ai_info
+    st.markdown("</div>", unsafe_allow_html=True)
 
-        if st.session_state.show_privacy_info:
-            render_subtle_callout(
-                "🔐",
-                "Privacy & anonymity",
-                """
-                <p>No personal data is collected—each game session is fully anonymous and none of your answers are saved or stored.</p>
-                <ul>
-                    <li>Gameplay progress lives only inside your local session (the drawn card, the preset questions you picked, whether you finished the round, and your final guess).</li>
-                    <li>Interactions rely solely on built-in widgets (radio buttons, select boxes, and buttons), so you never submit custom text or files to the app.</li>
-                    <li>Telemetry is disabled, preventing usage statistics from being collected.</li>
-                </ul>
-                """,
-            )
+    if st.session_state.show_privacy_info:
+        render_subtle_callout(
+            "🔐",
+            "Privacy & anonymity",
+            """
+            <p>No personal data is collected—each game session is fully anonymous and none of your answers are saved or stored.</p>
+            <ul>
+                <li>Gameplay progress lives only inside your local session (the drawn card, the preset questions you picked, whether you finished the round, and your final guess).</li>
+                <li>Interactions rely solely on built-in widgets (radio buttons, select boxes, and buttons), so you never submit custom text or files to the app.</li>
+                <li>Telemetry is disabled, preventing usage statistics from being collected.</li>
+            </ul>
+            """,
+        )
 
-        if st.session_state.show_ai_info:
-            render_subtle_callout(
-                "🤖",
-                "AI-generated content",
-                """
-                <p>Some of the code and content of this app has been AI generated. Humans have reviewed all AI generated content. Remember to label AI-generated content when sharing it.</p>
-                """,
-            )
+    if st.session_state.show_ai_info:
+        render_subtle_callout(
+            "🤖",
+            "AI-generated content",
+            """
+            <p>Some of the code and content of this app has been AI generated. Humans have reviewed all AI generated content. Remember to label AI-generated content when sharing it.</p>
+            """,
+        )
 
 # Initialize state
 if "game" not in st.session_state:


### PR DESCRIPTION
## Summary
- remove the sidebar "Show/hide info" expander and present the privacy and AI notice toggles directly below the new game button
- keep the existing toggle styling and callouts so players can still reveal the notices inline

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68ceec2c94b48321a971e300ffdc3a8f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced the collapsible expander with always-visible privacy and AI notices in the sidebar.
  * Simplified toggle placement and captions; reduced nesting for a cleaner layout.
  * Privacy & Anonymity and AI-generated content details now render inline only when their toggles are enabled.
  * Streamlined startup: initializes a new game via a simplified reset call.
  * Overall control flow updated to inline informational blocks for clearer, more consistent UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->